### PR TITLE
Docs/token-expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,13 @@ HUB_OFFLINE_TOKEN="your-access-token-here" # e.g. "ey...."
 
 ### Create ansible.cfg file
 
-An `ansible.cfg` file is required in the root directory for installing supported AAP collections from Red Hat Automation Hub. Replace `<HUB_TOKEN>` below with teh value of `HUB_OFFLINE_TOKEN` that is retrieved in the previous step.
+An `ansible.cfg` file is required in the root directory for installing supported AAP collections from Red Hat Automation Hub. Replace `<HUB_TOKEN>` below with the value of `HUB_OFFLINE_TOKEN` that is retrieved in the previous step.
 
 > [!NOTE]
 > To access private content from Red Hat Automation Hub via `ansible-galaxy`, a token is required. This token is used in `ansible.cfg` but should **never be committed to source control**.
+
+> [!WARNING]  
+> The `HUB_OFFLINE_TOKEN` expires after 30 days of inactivity. Generate a new token if it has been 30 days or more since your last build.
 
 ```
 [galaxy]
@@ -106,3 +109,10 @@ If you intend to build a RHEL9 base image that is configured to trust Vault's CA
 ```bash
 make rhel9_base
 ```
+
+## Troubleshooting
+
+Double check the following if your builds are failing
+
+1. The tokens `RHSM_OFFLINE_TOKEN` and `HUB_OFFLINE_TOKEN` expire afer 30 days of inactivity. Ensure that new ones are generated if they are expired.
+2. Ensure that the `ansible.cfg` file is created in the root directory and that the `HUB_OFFLINE_TOKEN` matches the value used in the environment variable.

--- a/pre-reqs/README.md
+++ b/pre-reqs/README.md
@@ -10,7 +10,7 @@ export RHSM_OFFLINE_TOKEN="some_offline_token" #subscription offline token https
 export RHN_REGISTRY_SVC="16723312|svc-registry" #registry service account https://access.redhat.com/terms-based-registry/
 export RHN_REGISTRY_TOKEN="ey---------"
 export AAP_ADMIN_PASSWORD="Hashi123!" #Ansible Automation Platform admin password. Set your own password.
-export HUB_OFFLINE_TOKEN="ey..." #Automation Hub offline token https://console.redhat.com/ansible/automation-hub/token
+export HUB_OFFLINE_TOKEN="ey..." #Automation Hub offline token https://console.redhat.com/ansible/automation-hub/token expires with 30 days inactivity
 ```
 
 # 1. Partner connect
@@ -84,6 +84,9 @@ Copy the offline token. This is used for `RHSM_OFFLINE_TOKEN`
 
 ![copy token](./docs/03-offline-token/02-copy-token.png)
 
+> [!WARNING]  
+> This token expires after 30 days of inactivity. Generate a new token if it has been 30 days or more since your last build.
+
 # 4. Registry Service Account
 
 Enter https://access.redhat.com/terms-based-registry/ and choose `New Service Account`
@@ -111,3 +114,6 @@ Enter https://console.redhat.com/ansible/automation-hub/token and under `Offline
 This displays the offline token. Copy the offline token. This is used for `HUB_OFFLINE_TOKEN`
 
 ![offline token](./docs/05-hub-token/02-offline-token.png)
+
+> [!WARNING]  
+> This token expires after 30 days of inactivity. Generate a new token if it has been 30 days or more since your last build.


### PR DESCRIPTION
- Add warnings that `RHN_REGISTRY_TOKEN` and `HUB_OFFLINE_TOKEN` expire after 30 days of inactivity. Both tokens must be renewed for the build to be successful.
- Add troubleshooting tips for failed builds